### PR TITLE
replace locationToURL with ability to provide urlBuilder

### DIFF
--- a/test/druidRequesterIntercept.mocha.js
+++ b/test/druidRequesterIntercept.mocha.js
@@ -65,6 +65,38 @@ describe("Druid requester static data source", function() {
       .done();
   });
 
+  it("works with a different URL builder", (testComplete) => {
+    var druidRequester = druidRequesterFactory({
+      host: 'localhost',
+      urlBuilder: (location) => {
+        return `http://${location.hostname}/proxy`
+      }
+    })
+
+    nock('http://localhost')
+      .post('/proxy/druid/v2/', {
+        'queryType': 'topN',
+        'dataSource': 'dsz'
+      })
+      .reply(200, {
+        lol: 'data'
+      });
+
+    druidRequester({
+      query: {
+        'queryType': 'topN',
+        'dataSource': 'dsz'
+      }
+    })
+      .then((res) => {
+        expect(res).to.deep.equal({
+          lol: 'data'
+        });
+        testComplete();
+      })
+      .done();
+  });
+
   it("works with simple headers POST (sync)", (testComplete) => {
     var druidRequester = druidRequesterFactory({
       host: 'a.druid.host',


### PR DESCRIPTION
Currently, it's not possible to change [the way request URLs are built](https://github.com/implydata/plywood-druid-requester/blob/2a325fd82105683d4ea06c0bb3d3e5407c030195/src/druidRequester.ts#L85). With this change, the consumer has more control over how URLs are built.

As an example, this now makes it possible to pass requests through a proxy that isn't running on the root path, like so:

```javascript
druidRequesterFactory({
  host: 'localhost',
  urlBuilder: (location) => {
    return `${window.location.protocol}//${location.hostname}/proxy`;
  }
});
```