### PR TITLE
[IMPLY-5484] bearer auth token type

### DIFF
--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -127,6 +127,11 @@ export function applyAuthTokenToHeaders(headers: Record<string, string>, authTok
       headers["Imply-HMAC"] = authToken.implyHmac;
       break;
 
+    case 'bearer-auth':
+      if (typeof authToken.bearerToken !== 'string') throw new Error('bearer-auth must set implyIdentityToken');
+      headers["Authorization"] = authToken.bearerToken;
+      break;
+
     default:
       throw new Error(`unknown auth token type '${authToken.type}'`);
   }

--- a/test/druidRequesterIntercept.mocha.js
+++ b/test/druidRequesterIntercept.mocha.js
@@ -165,6 +165,42 @@ describe("Druid requester intercept", function() {
       });
   });
 
+  it("works with a bearer auth token", () => {
+    let druidRequester = druidRequesterFactory({
+      host: 'localhost',
+      authToken: {
+        type: 'bearer-auth',
+        bearerToken: 'Bearer: abc123def456',
+      }
+    });
+
+    nock('http://localhost:8082', {
+      reqheaders: {
+        'Authorization': 'Bearer: abc123def456',
+      }
+    })
+      .post('/druid/v2/', {
+        'queryType': 'topNz',
+        'dataSource': 'dsz'
+      })
+      .reply(200, {
+        lol: 'data'
+      });
+
+    return toArray(druidRequester({
+      query: {
+        'queryType': 'topNz',
+        'dataSource': 'dsz'
+      }
+    }))
+      .then((res) => {
+        expect(res.length).to.equal(1);
+        expect(res[0]).to.deep.equal({
+          lol: 'data'
+        });
+      });
+  });
+
   context('with sync requestDecorator', () => {
     let druidRequester;
 

--- a/test/druidRequesterIntercept.mocha.js
+++ b/test/druidRequesterIntercept.mocha.js
@@ -170,13 +170,13 @@ describe("Druid requester intercept", function() {
       host: 'localhost',
       authToken: {
         type: 'bearer-auth',
-        bearerToken: 'Bearer: abc123def456',
+        bearerToken: 'Bearer abc123def456',
       }
     });
 
     nock('http://localhost:8082', {
       reqheaders: {
-        'Authorization': 'Bearer: abc123def456',
+        'Authorization': 'Bearer abc123def456',
       }
     })
       .post('/druid/v2/', {


### PR DESCRIPTION
Don't merge this until plywood-base-api is bumped to a version containing this code: https://github.com/implydata/plywood-base-api/pull/1