### PR TITLE
Catch errors when parsing Druid response

### DIFF
--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -464,7 +464,9 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
                     .pipe(new Combo({ packKeys: true, packStrings: true, packNumbers: true }))
                     .on('error', streamError)
                     .pipe(rowBuilder)
-                    .pipe(stream, { end: false });
+                    .on('error', streamError)
+                    .pipe(stream, { end: false })
+                    .on('error', streamError);
 
                   // rq.on('error', (e: any) => stream.emit('error', e));
                   // rq.on('data', (c: any) => stream.push(c));

--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -462,6 +462,7 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
 
                   response
                     .pipe(new Combo({ packKeys: true, packStrings: true, packNumbers: true }))
+                    .on('error', streamError)
                     .pipe(rowBuilder)
                     .pipe(stream, { end: false });
 


### PR DESCRIPTION
Currently, error handlers for the response stream are only attached if the status code is not 200. However, in cases where the response code _is_ 200 and the response body is invalid (i.e. cannot be parsed into valid JSON by `stream-json`), requester throws an unhandled stream error, which actually crashes the parent Node process.

This PR adds error handlers for the whole pipe chain when processing the Druid response.