### PR TITLE
Updated 'bad response' error to give more details

### DIFF
--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -422,7 +422,7 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
                           if (body && typeof body.host === 'string') error.host = body.host;
                         }
                       } catch (e) {
-                        error = new Error("bad response");
+                        error = new Error(`bad response: ${e.message}`);
                       }
 
                       streamError(error);


### PR DESCRIPTION
Jira Task: [IMPLY-6547](https://implydata.atlassian.net/browse/IMPLY-6547)

Purpose

Make fall through error give more details.

Context (Optional)

The `druidRequester` was giving a general "fall through" error of `bad response` and Wylie wrote this bug requesting the error give more details.

Key Changes

Added code to also log the error.message.