### PR TITLE
Fix: Return original response string in event of a parse error [IMPLY-35255]

### DIFF
--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -432,7 +432,7 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
                           if (body && typeof body.host === 'string') error.host = body.host;
                         }
                       } catch (e) {
-                        error = new Error(`bad response: ${e.message}`);
+                        error = new Error(`bad response: ${resp}`);
                       }
 
                       streamError(error);

--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -432,7 +432,7 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
                           if (body && typeof body.host === 'string') error.host = body.host;
                         }
                       } catch (e) {
-                        error = new Error(`bad response: ${resp}`);
+                        error = new Error(`bad response: ${e.message}` + '\n' + resp);
                       }
 
                       streamError(error);


### PR DESCRIPTION
When a non-200 response comes back from druid to the requester we currently attempt to parse it and return the an error message based on that json. This logic is wrapped in a try catch that returns the message from the parse error which the pivot -saas-server logs in data dog which can be quite confusing and remove the any useful error information. It appears that Druid is sending back html in a lot of these cases so in order to preserve the original error message we should just attach the response string. 
<img width="1176" alt="Screen Shot 2023-07-20 at 1 33 08 PM" src="https://github.com/implydata/plywood-druid-requester/assets/37322608/8a3fd38f-a8ca-458b-bab8-8f591c9903f6">
