### PR TITLE
Ensure query cancellation request includes all options

### DIFF
--- a/src/druidRequester.ts
+++ b/src/druidRequester.ts
@@ -447,11 +447,15 @@ export function druidRequesterFactory(parameters: DruidRequesterParameters): Ply
             cancelToken.promise
               .then(() => {
                 return requestPromise({
+                  ...options,
                   method: 'DELETE',
                   url: url + endpointPaths.native + queryId,
                 });
               })
-              .catch(() => {}); // Don't worry node about it if it fails
+              .catch(e => {
+                console.error(`Failed to cancel query "${queryId}"`);
+                console.error(e.stack);
+              });
           }
         }
 


### PR DESCRIPTION
Fixes an issue where query cancellation requests would silently fail with 401 because the authorization header was not being included.